### PR TITLE
configurable drift for verification (#3)

### DIFF
--- a/lib/hmac_auth/rack.rb
+++ b/lib/hmac_auth/rack.rb
@@ -2,7 +2,7 @@ require 'hmac_auth/x_headers'
 
 module HMACAuth
   module Rack
-    def self.verify(env, ttl: HMACAuth.default_ttl, secret: nil)
+    def self.verify(env, drift: HMACAuth.default_drift, ttl: HMACAuth.default_ttl, secret: nil)
       request_id = env.fetch(HMACAuth::XHeaders.rack_request_id)
       return false unless request_id
       key        = request_id.split('-').first
@@ -11,6 +11,7 @@ module HMACAuth
         signature: env.fetch(HMACAuth::XHeaders.rack_signature),
         method: env.fetch('REQUEST_METHOD'),
         ttl: ttl,
+        drift: drift,
         request_id: request_id,
         path: env.fetch('PATH_INFO'),
         secret: secret,

--- a/lib/hmac_auth/version.rb
+++ b/lib/hmac_auth/version.rb
@@ -1,3 +1,3 @@
 module HMACAuth
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/spec/hmac_auth_spec.rb
+++ b/spec/hmac_auth_spec.rb
@@ -44,6 +44,16 @@ describe HMACAuth do
       specify { expect(verification.call).to eq(false) }
       specify('with ample ttl') { expect(verification.call(ttl: 15)).to eq(true) }
     end
+
+    context 'signing clock is ahead of normal time' do
+      before do
+        allow(HMACAuth).to receive(:utc_timestamp) { Time.now.utc.to_i + 3 }
+        signature
+        allow(HMACAuth).to receive(:utc_timestamp).and_call_original
+      end
+      specify { expect(verification.call).to eq(true) }
+      specify('outside the allowed drift') { expect(verification.call(drift: 1)).to eq(false) }
+    end
   end
 
   describe HMACAuth::Faraday::Middleware do


### PR DESCRIPTION
@lumoslabs/platform 

(pulling in upstream changes; this was already reviewed).